### PR TITLE
Edited mkdocs.yml to correctly display clusters/index.md

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -8,6 +8,7 @@ nav:
       - 'about/index.md'
       - 'Contact Us': 'about/contact.md'
     - Clusters:
+      - 'clusters/index.md'
       - 'Wulver': 'clusters/wulver.md'
       - 'Lochness': 'clusters/lochness.md'
       - 'Decommissioned':


### PR DESCRIPTION
Clusters/index.md was not added to mkdocs.yml and was showing up elsewhere in the navigation 