### PR TITLE
remove --gres=gpu:2 for debug node

### DIFF
--- a/docs/Software/slurm/slurm.md
+++ b/docs/Software/slurm/slurm.md
@@ -177,7 +177,7 @@ The "debug" QoS in Slurm is intended for debugging and testing jobs. It usually 
 === "Debug Nodes"
 
      ```bash
-        srun -p debug -n 1 --ntasks-per-node=4 --qos=debug --account=PI_ucid --mem-per-cpu=2G --gres=gpu:2 --time=59:00 --pty bash
+        srun -p debug -n 1 --ntasks-per-node=4 --qos=debug --account=PI_ucid --mem-per-cpu=2G --time=59:00 --pty bash
      ```
 
 Replace `PI_ucid` with PI's NJIT UCID. 


### PR DESCRIPTION
--gres=gpu:2 is not valid for the debug node

 srun -p debug -n 1 --ntasks-per-node=4 --qos=debug --account=PI_ucid --mem-per-cpu=2G <del> --gres=gpu:2 </del> --time=59:00 --pty bash